### PR TITLE
Update tags var with the map of string type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -86,4 +86,7 @@ variable "lb_security_groups" {
   type        = list(string)
 }
 
-variable "tags" {}
+variable "tags" {
+  description = "Tags definition to apply to resources"
+  type        = map(string)
+}


### PR DESCRIPTION
## Purpose

The tags variable type wasn't defined properly. This causes some issues on latest versions.
The PR comes to fix it.

## Related issues

- https://github.com/rhythmictech/terraform-aws-asg-rollingupdate/issues/6