### PR TITLE
Make Autoscaling group PauseTime configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Terraform module to create Autoscaling Group in AWS with AutoScalingRollingUpdat
 | max\_instances | Max instances in ASG | `string` | `4` | no |
 | min\_instances | Min instances in ASG | `string` | `2` | no |
 | name | common name for resources in this module | `string` | `"ec2-spot-cluster"` | no |
+| pause\_time | Time to wait for a new instance to check-in before marking it as failed. Specify PauseTime in the ISO8601 duration format (in the format PT#H#M#S, where each # is the number of hours, minutes, and seconds, respectively). | `string` | `"PT5M"` | no |
 | scaling\_object\_type | The object type the autoscaling group should use as the basis for its instances. The default (and currently the only supported) value is 'LaunchTemplate'. Future values may include 'MixedInstancesPolicy', 'LaunchConfigurationName', and 'InstanceId' | `string` | `"launchtemplate"` | no |
 
 ## Outputs

--- a/auto-scaling-group.yml.tpl
+++ b/auto-scaling-group.yml.tpl
@@ -57,7 +57,7 @@ Resources:
         MaxBatchSize: "${maxBatch}"
         MinInstancesInService: "${minInService}"
         MinSuccessfulInstancesPercent: 80
-        PauseTime: PT5M
+        PauseTime: "${pauseTime}"
         SuspendProcesses:
           - HealthCheck
           - ReplaceUnhealthy

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,7 @@ data "template_file" "this" {
     maxSize                  = var.max_instances
     minInService             = var.min_instances_in_service
     minSize                  = var.min_instances
+    pauseTime                = var.pause_time
     scalingObject            = var.scaling_object_type
     tags                     = local.tags_lt_format
     targetGroups             = aws_lb_target_group.this.id

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,12 @@ variable "name" {
   type        = string
 }
 
+variable "pause_time" {
+  default     = "PT5M"
+  description = "Time to wait for a new instance to check-in before marking it as failed. Specify PauseTime in the ISO8601 duration format (in the format PT#H#M#S, where each # is the number of hours, minutes, and seconds, respectively). "
+  type        = string
+}
+
 variable "subnet_ids" {
   description = "Subnets ALB will listen on"
   type        = list(string)


### PR DESCRIPTION
Making PauseTime a variable for this module so we can adjust how long the ASG waits for a node to come up instead of defaulting to 5 minutes